### PR TITLE
Add Title to trade listings extension

### DIFF
--- a/app/Http/Controllers/Users/TradeController.php
+++ b/app/Http/Controllers/Users/TradeController.php
@@ -76,7 +76,7 @@ class TradeController extends Controller
     public function getTrade($id)
     {
         $trade = Trade::find($id);
-        
+
         if($trade->status != 'Completed' && !Auth::user()->hasPower('manage_characters') && !($trade->sender_id == Auth::user()->id || $trade->recipient_id == Auth::user()->id))   $trade = null;
 
         if(!$trade) abort(404);
@@ -146,7 +146,7 @@ class TradeController extends Controller
             'page' => 'trade'
         ]);
     }
-    
+
     /**
      * Creates a new trade.
      *
@@ -165,7 +165,7 @@ class TradeController extends Controller
         }
         return redirect()->back();
     }
-    
+
     /**
      * Edits a trade.
      *
@@ -196,12 +196,12 @@ class TradeController extends Controller
         $trade = Trade::where('id', $id)->where(function($query) {
             $query->where('recipient_id', Auth::user()->id)->orWhere('sender_id', Auth::user()->id);
         })->where('status', 'Open')->first();
-        
+
         return view('home.trades._confirm_offer_modal', [
             'trade' => $trade
         ]);
     }
-    
+
     /**
      * Confirms or unconfirms an offer.
      *
@@ -232,12 +232,12 @@ class TradeController extends Controller
         $trade = Trade::where('id', $id)->where(function($query) {
             $query->where('recipient_id', Auth::user()->id)->orWhere('sender_id', Auth::user()->id);
         })->where('status', 'Open')->first();
-        
+
         return view('home.trades._confirm_trade_modal', [
             'trade' => $trade
         ]);
     }
-    
+
     /**
      * Confirms or unconfirms a trade.
      *
@@ -268,12 +268,12 @@ class TradeController extends Controller
         $trade = Trade::where('id', $id)->where(function($query) {
             $query->where('recipient_id', Auth::user()->id)->orWhere('sender_id', Auth::user()->id);
         })->where('status', 'Open')->first();
-        
+
         return view('home.trades._cancel_trade_modal', [
             'trade' => $trade
         ]);
     }
-    
+
     /**
      * Cancels a trade.
      *
@@ -294,7 +294,7 @@ class TradeController extends Controller
     }
 
     /**********************************************************************************************
-    
+
         TRADE LISTINGS
 
     **********************************************************************************************/
@@ -384,7 +384,7 @@ class TradeController extends Controller
      */
     public function postCreateListing(Request $request, TradeListingManager $service)
     {
-        if($listing = $service->createTradeListing($request->only(['comments', 'contact', 'item_ids', 'quantities', 'stack_id', 'stack_quantity', 'offer_currency_ids', 'seeking_currency_ids', 'character_id', 'offering_etc', 'seeking_etc']), Auth::user())) {
+        if($listing = $service->createTradeListing($request->only(['title', 'comments', 'contact', 'item_ids', 'quantities', 'stack_id', 'stack_quantity', 'offer_currency_ids', 'seeking_currency_ids', 'character_id', 'offering_etc', 'seeking_etc']), Auth::user())) {
             flash('Trade listing created successfully.')->success();
             return redirect()->to($listing->url);
         }
@@ -406,7 +406,7 @@ class TradeController extends Controller
     {
         $listing = TradeListing::find($id);
         if(!$listing) abort(404);
-        
+
         if($service->markExpired(['id' => $id], Auth::user())) {
             flash('Listing expired successfully.')->success();
         }

--- a/app/Models/TradeListing.php
+++ b/app/Models/TradeListing.php
@@ -22,7 +22,7 @@ class TradeListing extends Model
      * @var array
      */
     protected $fillable = [
-        'user_id', 'comments', 'contact', 'data', 'expires_at'
+        'user_id', 'comments', 'contact', 'data', 'expires_at', 'title'
     ];
 
     /**
@@ -52,18 +52,20 @@ class TradeListing extends Model
      * @var array
      */
     public static $createRules = [
+        'title' => 'nullable|between:3,50',
         'comments' => 'nullable',
         'contact' => 'required',
         'seeking_etc' => 'nullable|between:3,100',
         'offering_etc' => 'nullable|between:3,100',
     ];
-    
+
     /**
      * Validation rules for character updating.
      *
      * @var array
      */
     public static $updateRules = [
+        'title' => 'nullable|between:3,50',
         'comments' => 'nullable',
         'contact' => 'required',
         'seeking_etc' => 'nullable|between:3,100',
@@ -71,7 +73,7 @@ class TradeListing extends Model
     ];
 
     /**********************************************************************************************
-    
+
         RELATIONS
 
     **********************************************************************************************/
@@ -79,13 +81,13 @@ class TradeListing extends Model
     /**
      * Get the user who posted the trade listing.
      */
-    public function user() 
+    public function user()
     {
         return $this->belongsTo('App\Models\User\User', 'user_id');
     }
 
     /**********************************************************************************************
-    
+
         SCOPES
 
     **********************************************************************************************/
@@ -103,7 +105,7 @@ class TradeListing extends Model
                     $query->where('expires_at', '>=', Carbon::now());
                 });
         });
-        
+
     }
 
     /**
@@ -119,11 +121,11 @@ class TradeListing extends Model
                     $query->where('expires_at', '<=', Carbon::now());
                 });
         });
-        
+
     }
 
     /**********************************************************************************************
-    
+
         ACCESSORS
 
     **********************************************************************************************/
@@ -135,9 +137,21 @@ class TradeListing extends Model
      */
     public function getDisplayNameAttribute()
     {
-        return $this->user->displayName .'\'s <a href="'. $this->url. '">Trade Listing</a> (#' . $this->id .')';
+        if($this->title == null) return $this->user->displayName .'\'s <a href="'. $this->url. '">Trade Listing</a> (#' . $this->id .')';
+        else return '<a href="'.$this->url.'" data-toggle="tooltip" title="'.$this->user->name.'\'s trade listing.">'.$this->title.'</a> (Trade Listing #' . $this->id .')';
     }
-    
+
+    /**
+     * Gets the Display Name of the trade listing with the title portion somewhat shorter.
+     *
+     * @return string
+     */
+    public function getDisplayNameShortAttribute()
+    {
+        if($this->title == null) return $this->user->displayName .'\'s <a href="'. $this->url. '">Trade Listing</a> (#' . $this->id .')';
+        else return '<a href="'.$this->url.'" data-toggle="tooltip" title="'.$this->user->name.'\'s trade listing.">'.$this->title.'</a>';
+    }
+
     /**
      * Check if the trade listing is active.
      *
@@ -171,11 +185,11 @@ class TradeListing extends Model
     }
 
     /**********************************************************************************************
-    
+
         OTHER FUNCTIONS
 
     **********************************************************************************************/
-    
+
     /**
      * Gets all characters involved in the trade listing.
      *

--- a/app/Services/TradeListingManager.php
+++ b/app/Services/TradeListingManager.php
@@ -46,6 +46,7 @@ class TradeListingManager extends Service
             if(!isset($data['contact'])) throw new \Exception("Please enter your preferred method(s) of contact.");
 
             $listing = TradeListing::create([
+                'title' => isset($data['title']) ? $data['title'] : null,
                 'user_id' => $user->id,
                 'comments' => isset($data['comments']) ? $data['comments'] : null,
                 'contact' => $data['contact'],
@@ -73,7 +74,7 @@ class TradeListingManager extends Service
                 $listing->data = json_encode($listingData);
                 $listing->save();
             }
-            
+
             // These checks are performed here, since it's faster and easier to check for the asset arrays (vs the separate inputs)
             if(!$listing->data) throw new \Exception("Please enter what you're seeking and offering.");
             if(!isset($listing->data['seeking']) && !isset($listing->data['seeking_etc'])) throw new \Exception("Please enter what you're seeking.");
@@ -85,7 +86,7 @@ class TradeListingManager extends Service
 
             return $this->commitReturn($listing);
 
-        } catch(\Exception $e) { 
+        } catch(\Exception $e) {
             $this->setError('error', $e->getMessage());
         }
         return $this->rollbackReturn(false);
@@ -109,9 +110,9 @@ class TradeListingManager extends Service
 
             $listing->expires_at = Carbon::now();
             $listing->save();
-            
+
             return $this->commitReturn($listing);
-        } catch(\Exception $e) { 
+        } catch(\Exception $e) {
             $this->setError('error', $e->getMessage());
         }
         return $this->rollbackReturn(false);
@@ -120,7 +121,7 @@ class TradeListingManager extends Service
     /**
      * Handles recording of assets on the seeking side of a trade listing, as well as initial validation.
      *
-     * @param  \App\Models\TradeListing $listing 
+     * @param  \App\Models\TradeListing $listing
      * @param  array                    $data
      * @return bool|array
      */
@@ -174,7 +175,7 @@ class TradeListingManager extends Service
             if($assetCount > $assetLimit) throw new \Exception("You may only include a maximum of {$assetLimit} things in a listing.");
 
             return $this->commitReturn(['seeking' => $seekingAssets]);
-        } catch(\Exception $e) { 
+        } catch(\Exception $e) {
             $this->setError('error', $e->getMessage());
         }
         return $this->rollbackReturn(false);
@@ -183,7 +184,7 @@ class TradeListingManager extends Service
     /**
      * Handles recording of assets on the user's side of a trade listing, as well as initial validation.
      *
-     * @param  \App\Models\TradeListing $listing 
+     * @param  \App\Models\TradeListing $listing
      * @param  array                    $data
      * @param  \App\Models\User\User    $user
      * @return bool|array
@@ -195,7 +196,7 @@ class TradeListingManager extends Service
             $userAssets = createAssetsArray();
             $assetCount = 0;
             $assetLimit = Config::get('lorekeeper.settings.trade_asset_limit');
-            
+
             // Attach items. They are not even held, merely recorded for display on the listing.
             if(isset($data['stack_id'])) {
                 foreach($data['stack_id'] as $key=>$stackId) {
@@ -239,7 +240,7 @@ class TradeListingManager extends Service
             if($assetCount > $assetLimit) throw new \Exception("You may only include a maximum of {$assetLimit} things in a listing.");
 
             return $this->commitReturn(['offering' => $userAssets]);
-        } catch(\Exception $e) { 
+        } catch(\Exception $e) {
             $this->setError('error', $e->getMessage());
         }
         return $this->rollbackReturn(false);

--- a/database/migrations/2021_01_19_165537_add_title_to_tradelistings.php
+++ b/database/migrations/2021_01_19_165537_add_title_to_tradelistings.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddTitleToTradelistings extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('trade_listings', function (Blueprint $table) {
+            $table->string('title')->after('id')->nullable()->default(null);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('trade_listings', function (Blueprint $table) {
+            $table->dropColumn('title');
+        });
+    }
+}

--- a/resources/views/home/trades/listings/_listing.blade.php
+++ b/resources/views/home/trades/listings/_listing.blade.php
@@ -1,8 +1,8 @@
 <div class="card mb-3">
     <div class="card-header">
-        <h2 class="mb-0"><a href="{{$listing->url}} ">Listing (#{{ $listing->id }})</a> : Posted by {!! $listing->user->displayName !!}
+        <h3 class="mb-0">{!! $listing->displayName !!} : Posted by {!! $listing->user->displayName !!}
             <a class="float-right" href="{{ url('reports/new?url=') . $listing->url }}"><i class="fas fa-exclamation-triangle" data-toggle="tooltip" title="Click here to report this trade listing." style="font-size:75%; opacity: 50%;"></i></a>
-        </h2>
+        </h3>
     </div>
     <div class="card-body">
         @if(isset($trade->terms_link) && $trade->terms_link)
@@ -18,15 +18,15 @@
             <hr />
         <div class="row">
             <div class="col-md-6">
-                <h3 class="card-heading">
+                <h5 class="card-heading">
                     Seeking:
-                </h3>
+                </h5>
                 @include('home.trades.listings._seeking_summary', ['user' => $listing->user, 'data' => isset($listing->data['seeking']) ? parseAssetData($listing->data['seeking']) : null, 'listing' => $listing, 'etc' => isset($listing->data['seeking_etc']) ? $listing->data['seeking_etc'] : null])
             </div>
             <div class="col-md-6">
-                <h3 class="card-heading">
+                <h5 class="card-heading">
                     Offering:
-                </h3>
+                </h5>
                 @include('home.trades.listings._offer_summary', ['user' => $listing->user, 'data' => isset($listing->data['offering']) ? parseAssetData($listing->data['offering']) : null, 'listing' => $listing, 'etc' => isset($listing->data['offering_etc']) ? $listing->data['offering_etc'] : null])
             </div>
         </div>

--- a/resources/views/home/trades/listings/create_listing.blade.php
+++ b/resources/views/home/trades/listings/create_listing.blade.php
@@ -10,12 +10,13 @@
 </h1>
 
 <p>
-    Create a new trade listing. 
+    Create a new trade listing.
     <strong>Some notes:</strong>
     <ul>
-        <li>You can't modify the listing after its creation, so make sure everything is in order!</li> 
-        <li>Note that you may only add up to <strong>{{ Config::get('lorekeeper.settings.trade_asset_limit') }}</strong> things to each side (seeking/offering) of a listing-- if necessary, please create a new listing to add more.</li> 
-        <li><strong>Note that this does not interact automatically with the trade system;</strong> while trade listings should <strong>not</strong> be tentative, including an item or character you own within a listing will not inherently do anything with the item/character(s), and you will need to add them to trade(s) on your own.</li> 
+        <li>The title should be informative and not include anything that breaks this site's rules.</li>
+        <li>You can't modify the listing after its creation, so make sure everything is in order!</li>
+        <li>Note that you may only add up to <strong>{{ Config::get('lorekeeper.settings.trade_asset_limit') }}</strong> things to each side (seeking/offering) of a listing-- if necessary, please create a new listing to add more.</li>
+        <li><strong>Note that this does not interact automatically with the trade system;</strong> while trade listings should <strong>not</strong> be tentative, including an item or character you own within a listing will not inherently do anything with the item/character(s), and you will need to add them to trade(s) on your own.</li>
         <ul><li>Traded items/characters are not automatically removed from a listing.</li></ul>
         <li>Listings expire after {{ $listingDuration }} days. You will also be able to manually mark a listing as expired before that point.</li>
     </ul>
@@ -24,12 +25,17 @@
 {!! Form::open(['url' => 'trades/listings/create']) !!}
 
     <div class="form-group">
+        {!! Form::label('title', 'Listing Title') !!}
+        {!! add_help('This is what the public will see as the trade listing. <br>Try to be informative.') !!}
+        {!! Form::text('title', null, ['class' => 'form-control', 'required']) !!}
+    </div>
+    <div class="form-group">
         {!! Form::label('comments', 'Comments (Optional)') !!} {!! add_help('This comment will be displayed on the trade index. You can write a helpful note here, for example to note down the purpose of the trade.') !!}
         {!! Form::textarea('comments', null, ['class' => 'form-control']) !!}
     </div>
     <div class="form-group">
-        {!! Form::label('contact', 'Preferred Method(s) of Contact') !!} 
-        {!! add_help('Enter in your preferred method(s) of contact. This field cannot be left blank.') !!} 
+        {!! Form::label('contact', 'Preferred Method(s) of Contact') !!}
+        {!! add_help('Enter in your preferred method(s) of contact. This field cannot be left blank.') !!}
         {!! Form::text('contact', null, ['class' => 'form-control', 'required']) !!}
     </div>
     <h2>Seeking <a class="small inventory-collapse-toggle collapse-toggle" href="#userSeeking" data-toggle="collapse">Show</a></h2>
@@ -63,8 +69,8 @@
         @endif
         <h3>Other</h3>
         <div class="form-group">
-            {!! Form::label('seeking_etc', 'Other Goods or Services') !!} 
-            {!! add_help('Enter in any goods/services you are seeking that are not handled by the site-- for example, art. This should be brief!') !!} 
+            {!! Form::label('seeking_etc', 'Other Goods or Services') !!}
+            {!! add_help('Enter in any goods/services you are seeking that are not handled by the site-- for example, art. This should be brief!') !!}
             {!! Form::text('seeking_etc', null, ['class' => 'form-control']) !!}
         </div>
     </div>
@@ -84,8 +90,8 @@
         @endif
         <h3>Other</h3>
         <div class="form-group">
-            {!! Form::label('offering_etc', 'Other Goods or Services') !!} 
-            {!! add_help('Enter in any goods/services you are offerering that are not handled by the site-- for example, art. This should be brief!') !!} 
+            {!! Form::label('offering_etc', 'Other Goods or Services') !!}
+            {!! add_help('Enter in any goods/services you are offerering that are not handled by the site-- for example, art. This should be brief!') !!}
             {!! Form::text('offering_etc', null, ['class' => 'form-control']) !!}
         </div>
     </div>

--- a/resources/views/home/trades/listings/view_listing.blade.php
+++ b/resources/views/home/trades/listings/view_listing.blade.php
@@ -6,7 +6,7 @@
 {!! breadcrumbs(['Trades' => 'trades/open', 'Listings' => 'trades/listings', 'Listing (#' . $listing->id . ')' => 'trades/listings/'.$listing->id]) !!}
 
 <h1>
-    Trade Listing (#{{ $listing->id }})
+    {!! $listing->displayName !!}
 
     <span class="float-right badge badge-{{ $listing->isActive ? 'success' : 'secondary' }}">{{ $listing->isActive ? 'Active' : 'Expired' }}</span>
 </h1>
@@ -40,7 +40,7 @@
             <div class="card-body">
                 @if($listing->comments)
                     {!! nl2br(htmlentities($listing->comments)) !!}
-                @else 
+                @else
                     No comment given.
                 @endif
             </div>
@@ -100,7 +100,7 @@
 @endsection
 
 @section('scripts')
-@parent 
+@parent
 @if($listing->isActive)
     <script>
         $(document).ready(function() {
@@ -109,7 +109,7 @@
 
             var $expireButton = $('#expireButton');
             var $expireSubmit = $('#expireSubmit');
-            
+
             $expireButton.on('click', function(e) {
                 e.preventDefault();
                 $confirmationModal.modal('show');


### PR DESCRIPTION
Apologies for the weird Spacing bits that github/sourcetree/VSC put it.

- Add "title" to trade listings, with safety checks for trade listings made before title was added. 
- Adds "DisplayNameShort" attribute to mimic display name but remove `(Trade Listing #1)`