### PR TITLE
Fixed errors caused by removed assets.

### DIFF
--- a/app/Models/ScavengerHunt/HuntTarget.php
+++ b/app/Models/ScavengerHunt/HuntTarget.php
@@ -149,8 +149,9 @@ class HuntTarget extends Model
      */
     public function getDisplayItemAttribute()
     {
-        $image = ($this->item->imageUrl) ? '<img class="small-icon" src="'.$this->item->imageUrl.'"/>' : null;
-        return $image.' '.$this->item->displayName.' ×'.$this->attributes['quantity'];
+		if (!$this->item) return 'Deleted Asset';
+		$image = ($this->item->imageUrl) ? '<img class="small-icon" src="'.$this->item->imageUrl.'"/>' : null;
+		return $image.' '.$this->item->displayName.' ×'.$this->attributes['quantity'];
     }
 
     /**
@@ -160,6 +161,7 @@ class HuntTarget extends Model
      */
     public function getDisplayItemLongAttribute()
     {
+		if (!$this->item) return 'Deleted Asset';
         $image = ($this->item->imageUrl) ? '<img style="max-height:150px;" src="'.$this->item->imageUrl.'" data-toggle="tooltip" title="'.$this->item->name.'"/>' : null;
         return $image.(isset($image) ? '<br/>' : '').' '.$this->item->displayName.' ×'.$this->attributes['quantity'];
     }
@@ -171,6 +173,7 @@ class HuntTarget extends Model
      */
     public function getDisplayItemShortAttribute()
     {
+		if (!$this->item) return 'Deleted Asset';
         $image = ($this->item->imageUrl) ? '<img style="max-height:150px;" src="'.$this->item->imageUrl.'" data-toggle="tooltip" title="'.$this->item->name.'"/>' : null;
         if(isset($image)) return $image;
         else return $this->item->displayName;
@@ -193,6 +196,7 @@ class HuntTarget extends Model
      */
     public function getDisplayLinkAttribute()
     {
+		if (!$this->item) return 'Deleted Asset';
         $image = ($this->item->imageUrl) ? '<img src="'.$this->item->imageUrl.'" alt="'.$this->item->name.'" />' : $this->item->name;
         return '<a href="'.$this->url.'">'.$image.'</a>';
     }
@@ -204,6 +208,7 @@ class HuntTarget extends Model
      */
     public function getWikiLinkAttribute()
     {
+		if (!$this->item) return 'Deleted Asset';
         $image = ($this->item->imageUrl) ? $this->item->imageUrl : $this->item->name;
         return '['.$this->url.' '.$image.']';
     }

--- a/resources/views/scavenger_hunts/hunt.blade.php
+++ b/resources/views/scavenger_hunts/hunt.blade.php
@@ -64,7 +64,7 @@
                         @foreach($logArray as $key => $found)
                             @if(isset($found))
                                 @if(isset($hunt->targets[$key - 1]->description))
-                                    <p>The <strong>{!! $hunt->targets[$key - 1]->item->name !!}</strong> had this message for you:</p>
+                                    <p>The <strong>{!! ($hunt->targets[$key - 1]->item) ? $hunt->targets[$key - 1]->item->name : 'Deleted Asset' !!}</strong> had this message for you:</p>
                                     <p>
                                         <i>{!! $hunt->targets[$key - 1]->description !!}</i>
                                     </p>


### PR DESCRIPTION
Assets removed by site administration cause a veritable spread of errors.

This should fix most of these errors, by replacing the name of the items to 'Deleted Asset'.
(This is consistent with the use of the term from a recent update that fixed a similar error in past submissions and claims.)