### PR TITLE
Fixed errors caused by removed assets.

### DIFF
--- a/app/Models/Advent/AdventCalendar.php
+++ b/app/Models/Advent/AdventCalendar.php
@@ -277,6 +277,7 @@ class AdventCalendar extends Model
     public function displayItem($day)
     {
         $item = $this->item($day);
+		if (!$item) return 'Deleted Asset';
         $image = ($item->imageUrl) ? '<img class="small-icon" src="'.$item->imageUrl.'"/>' : null;
         return $image.' '.$item->displayName.' ×'.$this->itemQuantity($day);
     }
@@ -290,6 +291,7 @@ class AdventCalendar extends Model
     public function displayItemLong($day)
     {
         $item = $this->item($day);
+		if (!$item) return 'Deleted Asset';
         $image = ($item->imageUrl) ? '<img style="max-height:150px;" src="'.$item->imageUrl.'" data-toggle="tooltip" title="'.$item->name.'"/>' : null;
         return $image.(isset($image) ? '<br/>' : '').' '.$item->displayName.' ×'.$this->itemQuantity($day);
     }
@@ -302,6 +304,7 @@ class AdventCalendar extends Model
     public function displayItemShort($day)
     {
         $item = $this->item($day);
+		if (!$item) return 'Deleted Asset';
         $image = ($item->imageUrl) ? '<img style="max-height:150px;" src="'.$item->imageUrl.'" data-toggle="tooltip" title="'.$item->name.'"/>' : null;
         if(isset($image)) return $image;
         else return $item->displayName;

--- a/app/Services/AdventService.php
+++ b/app/Services/AdventService.php
@@ -98,7 +98,8 @@ class AdventService extends Service
                 }
 
                 // Encode the prize data
-                $data['data'] = json_encode($data['data']);
+                if (isset($data['data'])) $data['data'] = json_encode($data['data']);
+				else $data['data'] = null;
             }
 
             $advent->update(Arr::only($data, ['name', 'display_name', 'summary', 'start_at', 'end_at', 'data']));

--- a/resources/views/admin/advents/create_edit_advent.blade.php
+++ b/resources/views/admin/advents/create_edit_advent.blade.php
@@ -131,7 +131,7 @@
                 {!! $participant->user->displayName !!}
             </div>
             <div class="col-md text-center">
-                {{ $participant->day }} - {!! $advent->item($participant->day)->displayName !!} ×{{ $advent->itemQuantity($participant->day) }}
+                {{ $participant->day }} - {!! ($advent->item($participant->day)) ? $advent->item($participant->day)->displayName : 'Deleted Asset' !!} ×{{ $advent->itemQuantity($participant->day) }}
             </div>
             <div class="col-md text-center">
                 {!! pretty_date($participant->claimed_at) !!}


### PR DESCRIPTION
Similarly to PR https://github.com/itinerare/lorekeeper/pull/8, assets removed by site administration cause a veritable spread of errors.

This should fix most of these errors, by replacing the name of the items to 'Deleted Asset'.
(This is consistent with the use of the term from a recent update that fixed a similar error in past submissions and claims.)

Includes minor fix that checks if data exists, change assisted by @itinerare.