### PR TITLE
fix: unable to save changes to the main loot table as "null" is not an integer

### DIFF
--- a/app/Services/LootService.php
+++ b/app/Services/LootService.php
@@ -140,7 +140,7 @@ class LootService extends Service
                 'quantity'        => $data['quantity'][$key],
                 'weight'          => $data['weight'][$key],
                 'data'            => isset($lootData) ? json_encode($lootData) : null,
-                'subtable_id'     => $data['subtable_id'][$key],
+                'subtable_id'     => $data['subtable_id'][$key] != 'null' ? $data['subtable_id'][$key] : null,
             ]);
         }
     }


### PR DESCRIPTION
When saving changes to the main table, the request returns "null" as a literal string - added a check for this to fix it