### PR TITLE
fix(donations): add withTrashed() to stack() relationship in UserItemDonation

### DIFF
--- a/app/Models/Shop/UserItemDonation.php
+++ b/app/Models/Shop/UserItemDonation.php
@@ -37,7 +37,7 @@ class UserItemDonation extends Model
      */
     public function stack()
     {
-        return $this->belongsTo('App\Models\User\UserItem');
+        return $this->belongsTo('App\Models\User\UserItem')->withTrashed();
     }
 
     /**


### PR DESCRIPTION
Certain extensions or features can cause the UserItem (stack) referenced by UserItemDonation to be marked as deleted, which will then cause a server error when attempting to view/claim the donated item (since, as far as it can tell, the stack no longer exists). Adding withTrashed() to the relationship fixes it, allowing for viewing and claiming of the item. As far as I could tell this doesn't seem to have any negative repercussions.